### PR TITLE
Minor changes to documentation and contribution guide

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+reported to the community leaders responsible for enforcement (Nick Crews).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/README.md
+++ b/README.md
@@ -49,11 +49,15 @@ record linkage packages.
 
 ## Examples
 
-See the [example notebook](https://nickcrews.github.io/mismo/examples/patent_deduplication)
+See the [example notebook](https://nickcrews.github.io/mismo/examples/patent_deduplication).
 
 ## Documentation
 
-See the [documentation](https://nickcrews.github.io/mismo)
+See the [documentation](https://nickcrews.github.io/mismo).
+
+## Contributing
+
+See the [contributing guide](https://nickcrews.github.io/mismo/contributing/).
 
 ## License
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,28 +2,26 @@
 
 ## Dependencies
 
-We use `PDM` as our project management tool. Install that per `PDM`'s instructions.
+We use [`PDM`](https://pdm-project.org) as our project management tool. Install that [per `PDM`'s instructions](https://pdm-project.org/latest/#recommended-installation-method). On Mac/Linux, you can install it with by running:
+```bash
+curl -sSL https://pdm-project.org/install-pdm.py | python3 -
+```
 
-Then, this is not necessary, but it makes things easier, we use `just` to automate
-many of the common development tasks. The rest of this guide will assume
-you have just installed, but if you don't want to use `just`, then you
-can run all the recipes manually, just look at the
-[justfile](https://github.com/NickCrews/mismo/blob/main/justfile)
-for the relevant recipe.
+As an optional tool, we use [`just`](https://just.systems/man/en/chapter_1.html) and a [justfile](https://github.com/NickCrews/mismo/blob/main/justfile) to automate many of the common development tasks. The rest of this guide will not assume that you have `just` installed.
 
 ## Setup dev environemnt
 
-Once `PDM` (and optionally `just`) are installed, run `just init`. This will
-create a virtual environment in `.venv/`, install all the locked dependencies
+Once `PDM` are installed, run `pdm install -d -G :all`. This will
+create a virtual environment in `.venv/` and install all the locked dependencies
 in `pdm.lock`.
 
 To enter the venv, use `. .venv/bin/activate`.
 You can exit the venv with `deactivate`, as usual.
 
 When you are in the venv, you can run common tasks such as
-- `just test`
-- `just fmt`
-- `just lint`
+- Running tests: `pytest`
+- Formatting code: `ruff format mismo docs `
+- Lint code: `ruff check mismo docs`
 
 See the [justfile](https://github.com/NickCrews/mismo/blob/main/justfile)
-for more recipes.
+for more tasks.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,26 +2,32 @@
 
 ## Dependencies
 
-We use [`PDM`](https://pdm-project.org) as our project management tool. Install that [per `PDM`'s instructions](https://pdm-project.org/latest/#recommended-installation-method). On Mac/Linux, you can install it with by running:
+We use [`PDM`](https://pdm-project.org) as our package and dependency management tool. Install that 
+[per `PDM`'s instructions](https://pdm-project.org/latest/#recommended-installation-method). 
+On Mac/Linux, this is done by running:
 ```bash
 curl -sSL https://pdm-project.org/install-pdm.py | python3 -
 ```
 
-As an optional tool, we use [`just`](https://just.systems/man/en/chapter_1.html) and a [justfile](https://github.com/NickCrews/mismo/blob/main/justfile) to automate many of the common development tasks. The rest of this guide will not assume that you have `just` installed.
+We use [`just`](https://just.systems/man/en/chapter_1.html) and a 
+[justfile](https://github.com/NickCrews/mismo/blob/main/justfile) 
+to automate many of the common development tasks. The rest of this guide will assume
+you have just installed. If you don't want to use `just`, you can manually run recipes from the 
+[justfile](https://github.com/NickCrews/mismo/blob/main/justfile).
 
 ## Setup dev environemnt
 
-Once `PDM` are installed, run `pdm install -d -G :all`. This will
-create a virtual environment in `.venv/` and install all the locked dependencies
+Once `PDM` (and optionally `just`) are installed, run `just init`. This will
+create a virtual environment in `.venv/`, install all the locked dependencies
 in `pdm.lock`.
 
 To enter the venv, use `. .venv/bin/activate`.
 You can exit the venv with `deactivate`, as usual.
 
 When you are in the venv, you can run common tasks such as
-- Running tests: `pytest`
-- Formatting code: `ruff format mismo docs `
-- Lint code: `ruff check mismo docs`
+- `just test`
+- `just fmt`
+- `just lint`
 
 See the [justfile](https://github.com/NickCrews/mismo/blob/main/justfile)
-for more tasks.
+for more recipes.


### PR DESCRIPTION
Minor documentation changes:
- Added links to PDM and `just` in contributing guide.
- Changed contribution guide to using PDM directly instead of `just`. Why? `just` is somewhat hard to install and not quite necessary for contributing.
- Added Nick Crews as responsible for code of conduct enforcement.
- Added a link in README to contributing guide.