### PR TITLE
Fix usage of ibis.range()

### DIFF
--- a/mismo/compare/_plot.py
+++ b/mismo/compare/_plot.py
@@ -255,7 +255,7 @@ def _make_level_color_scale(comparers: Iterable[LevelComparer]) -> alt.Scale:
     hues = _frange(0, 1, len(comparers))
     for comp, hue in zip(comparers, hues):
         levels = comp.levels
-        shades = _frange(0.2, 0.9, len(levels))
+        shades = _frange(0.9, 0.2, len(levels))
         for level_name, shade in zip(levels, shades):
             r, g, b = colorsys.hsv_to_rgb(hue, 1, shade)
             r = int(r * 255)

--- a/mismo/fs/_train.py
+++ b/mismo/fs/_train.py
@@ -135,11 +135,11 @@ def train_ms_from_labels(
 def _true_pairs_from_labels(left: ir.Table, right: ir.Table) -> ir.Table:
     if "label_true" not in left.columns:
         raise ValueError(
-            "Left dataset must have a label_true column. Found: {left.columns}"
+            f"Left dataset must have a label_true column. Found: {left.columns}"
         )
     if "label_true" not in right.columns:
         raise ValueError(
-            "Right dataset must have a label_true column. Found: {right.columns}"
+            f"Right dataset must have a label_true column. Found: {right.columns}"
         )
     return KeyBlocker("label_true")(left, right)
 


### PR DESCRIPTION
`ibis.range()` always requires three arguments ([doc](https://ibis-project.org/reference/expression-generic.html#ibis.range)).