### PR TITLE
fix: edge case when n_possible_pairs < max_pairs

### DIFF
--- a/mismo/block/_util.py
+++ b/mismo/block/_util.py
@@ -68,7 +68,7 @@ def sample_all_pairs(
     """  # noqa: E501
     left = left.cache()
     right = right.cache()
-    n_possible_pairs = left.count().execute() * right.count().execute()
+    n_possible_pairs = int(left.count().execute() * right.count().execute())
     n_pairs = (
         n_possible_pairs if max_pairs is None else min(n_possible_pairs, max_pairs)
     )

--- a/mismo/block/tests/test_util.py
+++ b/mismo/block/tests/test_util.py
@@ -18,7 +18,7 @@ from mismo.block import sample_all_pairs
         (2, 3),
         (10, 99),
         # Edge case where n_possible_pairs < max_pairs
-        (3, 10_000_000)
+        (3, 10_000_000),
     ],
 )
 def test_sample_all_pairs(table_factory, n_records: int, max_pairs: int):
@@ -30,7 +30,7 @@ def test_sample_all_pairs(table_factory, n_records: int, max_pairs: int):
         }
     )
     df = sample_all_pairs(t, t, max_pairs=max_pairs).execute()
-    expected_pairs = min(n_records ** 2, max_pairs)
+    expected_pairs = min(n_records**2, max_pairs)
     assert df.columns.tolist() == ["record_id_l", "record_id_r", "value_l", "value_r"]
     assert len(df) == expected_pairs
     assert df.record_id_l.notnull().all()


### PR DESCRIPTION
This PR fixes an issue in #63 that prevents `sample_all_pairs` from working as expected when `max_pairs` > `n_possible_pairs` 