### PR TITLE
Add implementation for built-in jaccard similarity

### DIFF
--- a/mismo/text/__init__.py
+++ b/mismo/text/__init__.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from mismo.text._features import ngrams as ngrams
+from mismo.text._features import tokenize as tokenize
 from mismo.text._similarity import damerau_levenshtein as damerau_levenshtein
 from mismo.text._similarity import (
     damerau_levenshtein_ratio as damerau_levenshtein_ratio,
 )
 from mismo.text._similarity import double_metaphone as double_metaphone
+from mismo.text._similarity import jaccard as jaccard
 from mismo.text._similarity import levenshtein_ratio as levenshtein_ratio
 from mismo.text._strings import norm_whitespace as norm_whitespace

--- a/mismo/text/_similarity.py
+++ b/mismo/text/_similarity.py
@@ -107,3 +107,22 @@ def _dist_ratio(s1, s2, dist):
     s2 = _util.ensure_ibis(s2, "string")
     lenmax = ibis.greatest(s1.length(), s2.length())
     return (lenmax - dist(s1, s2)) / lenmax
+
+
+@ibis.udf.scalar.builtin
+def jaccard(s1: str, s2: str) -> float:
+    """The Jaccard similarity between `s1` and `s2
+
+    This is equivalent to
+
+    ```python
+    from mismo.sets import jaccard as jaccard_set
+    from mismo.text import tokenize
+
+    t1 = tokenize(s1)
+    t2 = tokenize(s2)
+    jaccard_set(t1, t2)
+    ```
+
+    but is added here for convenience.
+    """

--- a/mismo/text/tests/test_similarity.py
+++ b/mismo/text/tests/test_similarity.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from mismo import text
+from mismo import sets, text
 
 
 @pytest.mark.parametrize(
@@ -38,3 +38,21 @@ def test_levenshtein_ratio(string1, string2, expected):
         assert np.isnan(result)
     else:
         assert expected == result
+
+
+@pytest.mark.parametrize(
+    "string1,string2,expected",
+    [
+        ("foo", "foo", 1),
+        ("foo bar", "foo", 0.3333),  # this is currently failing
+        ("foo bar", "bar foo", 1),
+    ],
+)
+def test_jaccard_string_similarity(string1, string2, expected):
+    """Test that the string and set jaccard methods are equivalent."""
+    result = text.jaccard(string1, string2).execute()
+    tokens1 = text.tokenize(string1)
+    tokens2 = text.tokenize(string2)
+    set_result = sets.jaccard(tokens1, tokens2).execute()
+    assert result == pytest.approx(set_result, 0.001)
+    assert result == pytest.approx(expected, 0.001)


### PR DESCRIPTION
Adds the duckdb builtin jaccard similarity which currently does not always result in the same value as `mismo.sets.jaccard`