### PR TITLE
Skip tests that require spacy when it is not installed

### DIFF
--- a/mismo/lib/geo/tests/_util.py
+++ b/mismo/lib/geo/tests/_util.py
@@ -1,0 +1,6 @@
+def is_spacy_installed() -> bool:
+    try:
+        import spacy  # noqa: F401
+        return True
+    except ImportError:
+        return False

--- a/mismo/lib/geo/tests/test_address.py
+++ b/mismo/lib/geo/tests/test_address.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import pytest
 
 from mismo.lib import geo
+from mismo.lib.geo.tests._util import is_spacy_installed
 
 
+@pytest.mark.skipif(not is_spacy_installed(), reason="spacy is not installed")
 @pytest.mark.parametrize(
     "addresses, expected",
     [

--- a/mismo/lib/geo/tests/test_spacy.py
+++ b/mismo/lib/geo/tests/test_spacy.py
@@ -4,8 +4,10 @@ import ibis
 import pytest
 
 from mismo.lib import geo
+from mismo.lib.geo.tests._util import is_spacy_installed
 
 
+@pytest.mark.skipif(not is_spacy_installed(), reason="spacy is not installed")
 @pytest.mark.parametrize(
     "address, expected",
     [


### PR DESCRIPTION
As spacy is declared as an optional dependency, unit tests that rely on it should be skipped when it is not installed.

Note: when spacy is missing the doctest for these files still fails, but I do not know how to skip them conditionally:
```
FAILED mismo/lib/geo/_address.py::mismo.lib.geo._address.AddressFeatures
FAILED mismo/lib/geo/_spacy.py::mismo.lib.geo._spacy.spacy_tag_address
```